### PR TITLE
Wars 517/ignore cache

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,8 @@
+{
+    "name": "escaleseo/simple-multisite-sitemaps",
+    "version": "dev-master",
+    "type": "wordpress-plugin",
+    "require": {
+        "composer/installers": "^1.5"
+    }
+}

--- a/simple-multisite-sitemaps.php
+++ b/simple-multisite-sitemaps.php
@@ -37,6 +37,51 @@ License: GPLv2
 \--------------------------------------------------------------------/
 */
 
+// plugin settings
+function jb_sms_settings_page()
+{
+    add_settings_section("section", "Options", null, "jb_sms");
+    add_settings_field("jb_sms-checkbox", "Add \"/\" at the end of every sitemap entry?", "jb_sms_slash_checkbox_display", "jb_sms", "section");  
+    register_setting("section", "jb_sms-checkbox");
+}
+
+function jb_sms_slash_checkbox_display()
+{
+   ?>
+        <!-- Here we are comparing stored value with 1. Stored value is 1 if user checks the checkbox otherwise empty string. -->
+        <input type="checkbox" name="jb_sms-checkbox" value="1" <?php checked(1, get_option('jb_sms-checkbox'), true); ?> /> 
+   <?php
+}
+
+
+add_action("admin_init", "jb_sms_settings_page");
+
+function jb_sms_page()
+{
+  ?>
+      <div class="wrap">
+         <h1>Simple Multisite Sitemaps</h1>
+  
+         <form method="post" action="options.php">
+            <?php
+               settings_fields("section");
+  
+               do_settings_sections("jb_sms");
+                 
+               submit_button(); 
+            ?>
+         </form>
+      </div>
+   <?php
+}
+
+function menu_item()
+{
+  add_submenu_page("options-general.php", "Sitemap Settings", "Sitemap Settings", "manage_options", "jb_sms", "jb_sms_page"); 
+}
+ 
+add_action("admin_menu", "menu_item");
+
 // flush!
 function jb_sms_sitemap_flush_rules() {
     global $wp_rewrite;
@@ -54,6 +99,7 @@ function jb_sms_xml_feed_rewrite($wp_rewrite) {
  
     $wp_rewrite->rules = $feed_rules + $wp_rewrite->rules;
 }
+
 add_filter( 'generate_rewrite_rules', 'jb_sms_xml_feed_rewrite' );
 
 // generate sitemap.xml using the template
@@ -70,4 +116,3 @@ function jb_sms_add_sitemap_to_robotstxt() {
 add_action( 'do_robotstxt', 'jb_sms_add_sitemap_to_robotstxt' );
 
 
-?>

--- a/simple-multisite-sitemaps.php
+++ b/simple-multisite-sitemaps.php
@@ -42,17 +42,24 @@ function jb_sms_settings_page()
 {
     add_settings_section("section", "Options", null, "jb_sms");
     add_settings_field("jb_sms-checkbox", "Add \"/\" at the end of every sitemap entry?", "jb_sms_slash_checkbox_display", "jb_sms", "section");  
+    add_settings_field("jb_sms-only_canonical", "Add only canonical domain to sitemap?", "jb_sms_only_canonical_display", "jb_sms", "section");  
     register_setting("section", "jb_sms-checkbox");
+    register_setting("section", "jb_sms-only_canonical");
 }
 
 function jb_sms_slash_checkbox_display()
 {
    ?>
-        <!-- Here we are comparing stored value with 1. Stored value is 1 if user checks the checkbox otherwise empty string. -->
         <input type="checkbox" name="jb_sms-checkbox" value="1" <?php checked(1, get_option('jb_sms-checkbox'), true); ?> /> 
    <?php
 }
 
+function jb_sms_only_canonical_display()
+{
+   ?>
+        <input type="checkbox" name="jb_sms-only_canonical" value="1" <?php checked(1, get_option('jb_sms-only_canonical'), true); ?> /> 
+   <?php
+}
 
 add_action("admin_init", "jb_sms_settings_page");
 
@@ -61,13 +68,10 @@ function jb_sms_page()
   ?>
       <div class="wrap">
          <h1>Simple Multisite Sitemaps</h1>
-  
          <form method="post" action="options.php">
             <?php
                settings_fields("section");
-  
                do_settings_sections("jb_sms");
-                 
                submit_button(); 
             ?>
          </form>
@@ -114,5 +118,3 @@ function jb_sms_add_sitemap_to_robotstxt() {
     echo "Sitemap: ".get_option('siteurl')."/sitemap.xml\n\n";
 }
 add_action( 'do_robotstxt', 'jb_sms_add_sitemap_to_robotstxt' );
-
-

--- a/sitemap-template.php
+++ b/sitemap-template.php
@@ -50,10 +50,18 @@ $query_args = array(
 );
 query_posts( $query_args );
 
+function get_custom_blog_permalink( $blog_id, $post_id ) {
+    $page_permalink = get_blog_permalink( $blog_id, $post_id );
+    if (!empty($_SERVER['HTTP_X_FORWARDED_PROTO'])) {
+        $page_permalink = 'https:' . preg_replace('#^https?.#', '', rtrim($page_permalink, '/'));
+    }
+    return $page_permalink;
+}
+
 if ( have_posts()) : while (have_posts() ) : the_post();
 ?>
 	<url>
-		<loc><?php echo get_blog_permalink( $blog_id, $post->ID ); ?></loc> 
+		<loc><?php echo get_custom_blog_permalink( $blog_id, $post->ID ); ?></loc> 
 		<lastmod><?php echo mysql2date( 'Y-m-d\TH:i:s+00:00', get_post_modified_time('Y-m-d H:i:s', true), false ); ?></lastmod> 
 		<changefreq>weekly</changefreq> 
 		<priority>0.6</priority>

--- a/sitemap-template.php
+++ b/sitemap-template.php
@@ -35,18 +35,18 @@ header( 'Content-Type: text/xml; charset=' . get_option( 'blog_charset' ), true 
 echo '<?xml version="1.0" encoding="'.get_option( 'blog_charset' ).'"?'.'>'; 
 ?>
 
-<urlset	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	    xsi:schemaLocation="http://www.sitemaps.org/schemas/sitemap/0.9 http://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd"
-	    xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+<urlset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.sitemaps.org/schemas/sitemap/0.9 http://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd"
+        xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
 
 <?php 
 global $blog_id;
 
 $query_args = array(
-	'post_type'   => array( 'post', 'page' ),
-	'post_status' => 'publish',
-	'orderby'     => 'date',
-	'posts_per_page' => -1
+    'post_type'   => array( 'post', 'page' ),
+    'post_status' => 'publish',
+    'orderby'     => 'date',
+    'posts_per_page' => -1
 );
 query_posts( $query_args );
 
@@ -55,17 +55,23 @@ function get_custom_blog_permalink( $blog_id, $post_id ) {
     if (!empty($_SERVER['HTTP_X_FORWARDED_PROTO'])) {
         $page_permalink = 'https:' . preg_replace('#^https?.#', '', rtrim($page_permalink, '/'));
     }
+    if (get_option('jb_sms-checkbox') == 1) {
+        if (substr($page_permalink, -1) != '/') {
+            $page_permalink = $page_permalink . '/';
+        }
+    }
+
     return $page_permalink;
 }
 
 if ( have_posts()) : while (have_posts() ) : the_post();
 ?>
-	<url>
-		<loc><?php echo get_custom_blog_permalink( $blog_id, $post->ID ); ?></loc> 
-		<lastmod><?php echo mysql2date( 'Y-m-d\TH:i:s+00:00', get_post_modified_time('Y-m-d H:i:s', true), false ); ?></lastmod> 
-		<changefreq>weekly</changefreq> 
-		<priority>0.6</priority>
-	</url>
+    <url>
+        <loc><?php echo get_custom_blog_permalink( $blog_id, $post->ID ); ?></loc> 
+        <lastmod><?php echo mysql2date( 'Y-m-d\TH:i:s+00:00', get_post_modified_time('Y-m-d H:i:s', true), false ); ?></lastmod> 
+        <changefreq>weekly</changefreq> 
+        <priority>0.6</priority>
+    </url>
 <?php 
 endwhile; endif;
 ?> 

--- a/sitemap-template.php
+++ b/sitemap-template.php
@@ -64,7 +64,19 @@ function get_custom_blog_permalink( $blog_id, $post_id ) {
     return $page_permalink;
 }
 
-if ( have_posts()) : while (have_posts() ) : the_post();
+if (get_option('jb_sms-only_canonical') == 1):
+    $permalink = get_custom_blog_permalink($blog_id, $post->ID);
+    $canonical_domain = parse_url($permalink, PHP_URL_SCHEME) . '://' . parse_url($permalink, PHP_URL_HOST);
+?>
+    <url>
+        <loc><?php echo $canonical_domain; ?></loc>
+        <lastmod><?php echo mysql2date( 'Y-m-d\TH:i:s+00:00', get_post_modified_time('Y-m-d H:i:s', true), false ); ?></lastmod> 
+        <changefreq>weekly</changefreq> 
+        <priority>0.6</priority>
+    </url>
+<?php
+else:
+    if ( have_posts()) : while (have_posts() ) : the_post();
 ?>
     <url>
         <loc><?php echo get_custom_blog_permalink( $blog_id, $post->ID ); ?></loc> 
@@ -74,5 +86,6 @@ if ( have_posts()) : while (have_posts() ) : the_post();
     </url>
 <?php 
 endwhile; endif;
+endif;
 ?> 
 </urlset>

--- a/sitemap-template.php
+++ b/sitemap-template.php
@@ -72,7 +72,7 @@ if (get_option('jb_sms-only_canonical') == 1):
         <loc><?php echo $canonical_domain; ?></loc>
         <lastmod><?php echo mysql2date( 'Y-m-d\TH:i:s+00:00', get_post_modified_time('Y-m-d H:i:s', true), false ); ?></lastmod> 
         <changefreq>weekly</changefreq> 
-        <priority>0.6</priority>
+        <priority>1.0</priority>
     </url>
 <?php
 else:
@@ -82,7 +82,7 @@ else:
         <loc><?php echo get_custom_blog_permalink( $blog_id, $post->ID ); ?></loc> 
         <lastmod><?php echo mysql2date( 'Y-m-d\TH:i:s+00:00', get_post_modified_time('Y-m-d H:i:s', true), false ); ?></lastmod> 
         <changefreq>weekly</changefreq> 
-        <priority>0.6</priority>
+        <priority>1.0</priority>
     </url>
 <?php 
 endwhile; endif;

--- a/sitemap-template.php
+++ b/sitemap-template.php
@@ -32,6 +32,8 @@
 */
 header( 'HTTP/1.0 200 OK' );
 header( 'Content-Type: text/xml; charset=' . get_option( 'blog_charset' ), true );
+header( 'Cache-Control: public, must-revalidate, proxy-revalidate, max-age=0' );
+
 echo '<?xml version="1.0" encoding="'.get_option( 'blog_charset' ).'"?'.'>'; 
 ?>
 


### PR DESCRIPTION
In order to avoid cloudfront cache, but without explicitly telling `no-cache`, avoiding full sitemap.xml transfer in every request, it adds the following header.
```
Cache-Control: public, must-revalidate, proxy-revalidate, max-age=0
```

